### PR TITLE
collection title cleaning and tagline change

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
         <div class="logo-header">
             <a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/drc.logo.horizontal.png" alt="Digital Research Center at Hofstra" height="42" width="247" /></a>
             <a href="#" id="js-navigation-mobile-menu" class="mobile-toggle">MENU</a>
-            <p id="description">Finding Digital Solutions to Problems in Scholarship and Learning</p>
+            <p id="description">Digital Solutions to Problems in Scholarship and Learning</p>
         </div>
 
     </div>

--- a/_posts/2017-04-21-african-americans-on-long-island-collection.md
+++ b/_posts/2017-04-21-african-americans-on-long-island-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: African Americans on Long Island Collection, 1779- . 0.8 cubic ft.
+title: African Americans on Long Island Collection, 1779-current
 categories: special-collections
 published: true
 feature: true

--- a/_posts/2017-04-21-authors-collection.md
+++ b/_posts/2017-04-21-authors-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Authors Collection, 1795-1974. 12.8 cubic ft.
+title: Authors Collection, 1795-1974
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The collection, which spans the years 1795 through 1974, consists of correspondence with some manuscript materials, printed materials, and photographs. Among the authors represented in the collection are Edmund Blunden, William Cullen Bryant, Joseph Conrad, Albert Einstein, E.M. Forster, Robert Francis, Robert Frost, John Keats, Archibald MacLeish, Ellsworth Mason, H.L. Mencken, Bertrand Russel, Siegfried Sassoon, George Bernard Shaw, Upton Sinclair, Edith Wharton, Virginia Woolf, and W.B. Yeats.
 <!-- more -->
-

--- a/_posts/2017-04-21-binnian.md
+++ b/_posts/2017-04-21-binnian.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Binnian, Jacqueline Collection, 1923-2004. (bulk dates 1988-2000). 39.7 cubic ft.
+title: Binnian, Jacqueline Collection, 1923-2004
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ Jacqueline Binnian dedicated over 40 years of her life to the preservation of th
 
 Collection includes correspondence, news clippings, newsletters, minutes of meetings, photographs, maps, resolutions, land indentures, books, periodicals and other published materials, reports, agendas, public notices, drafts, notes, audio and video recordings, blueprints and plans, by-laws, articles of incorporation, government documents, address lists, contact information, budget reports, town code, proposals, federal and state legislation, promotional materials, public statements, press releases and ephemera.
 <!-- more -->
-

--- a/_posts/2017-04-21-carman-family-collection.md
+++ b/_posts/2017-04-21-carman-family-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Carman Family Collection, 1679-1942. 12.7 cubic ft.
+title: Carman Family Collection, 1679-1942
 categories: special-collections
 published: true
 feature: false
@@ -15,4 +15,3 @@ Included in the collection, which spans the years 1679-1942, are business record
 
 Noteworthy items include a small number of slave indentures and other documents that make reference to slaves.
 <!-- more -->
-

--- a/_posts/2017-04-21-davidson.md
+++ b/_posts/2017-04-21-davidson.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Davidson, Bernice and Reuben. Collection, 1946-2004. 3.8 cubic ft.
+title: Davidson, Bernice and Reuben. Collection, 1946-2004
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ Bernice and Reuben Davidson were humanitarian and political activists on Long Is
 
 The collection is comprised of articles, correspondence, publications, reports, photographs, and memorabilia.
 <!-- more -->
-

--- a/_posts/2017-04-21-dunn.md
+++ b/_posts/2017-04-21-dunn.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Dunn, Stephen, 1939- . Collection, 1947-2009. 23.0 cubic ft.
+title: Dunn, Stephen, 1939- . Collection, 1947-2009
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The Stephen Dunn Collection at Hofstra University consists of the personal and professional papers of Dunn, including various publications in which he appeared throughout his career. These are in the form of volumes, magazines, and articles. Also included is correspondence with other poets, in which they discuss Dunn’s poetry or the correspondents’. The collection also includes personal correspondence with friends and colleagues regarding topics other than poetry, as well as fan mail. A large part of the collection consists of early versions of his poetry, many of which are handwritten or notebook versions. There is also memorabilia from the Pulitzer Prize celebration and a scrapbook of that event.
 <!-- more -->
-

--- a/_posts/2017-04-21-engerer-family-papers.md
+++ b/_posts/2017-04-21-engerer-family-papers.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Engerer Family Papers, c.1920-1964, 2008. 1.5 cubic ft.
+title: Engerer Family Papers, c.1920-1964, 2008
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ Captain Ernest Engerer immigrated to the United States from Germany circa 1914, 
 
 The collection includes family and business photographs; performance flyers, programs, posters, advertisements; business papers; news clippings; and an oral history.
 <!-- more -->
-

--- a/_posts/2017-04-21-freese.md
+++ b/_posts/2017-04-21-freese.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Freese, Walter C., 1903-1968. Collection, 1920-1996. 4.7 cubic ft.
+title: Freese, Walter C. (1903-1968) Collection, 1920-1996
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ Dr. Walter C. Freese graduated from the University of Buffalo School of Medicine
 
 The collection, which spans the years 1920-1996, consists of certificates and diplomas, family photographs and photo albums, newspaper clippings, and scrapbooks compiled by Freese and his family. Also included in the collection is Freese’s medical bag, medical and surgical supplies, and four medical books.
 <!-- more -->
-

--- a/_posts/2017-04-21-harbor-hill.md
+++ b/_posts/2017-04-21-harbor-hill.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Harbor Hill, Mackay/Hechler Collection 1900-2000. 5.4 cubic ft.
+title: Harbor Hill, Mackay/Hechler Collection 1900-2000
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ Harbor Hill was a Gold Coast estate located in Roslyn, Long Island, New York, an
 
 The collection is composed of correspondence, newspaper clippings, bills, photographs of members of the Mackay and Hechler families and Harbor Hill. There are also many collected pieces of ephemera and maps.
 <!-- more -->
-

--- a/_posts/2017-04-21-hispanic-latino-collection.md
+++ b/_posts/2017-04-21-hispanic-latino-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Hispanic/Latino Collection, 1951- . 24.0 cubic ft.
+title: Hispanic/Latino Collection, 1951-current
 categories: special-collections
 published: true
 feature: false
@@ -15,4 +15,3 @@ Collection includes biographical information, CDs, correspondence, musical instr
 
 Noteworthy among the collection are research materials about the racially charged incidents at Farmingville, Círculo de la Hispanidad's lawsuit against the City of Long Beach, and the battle against English-only legislation that was waged by the Coalition for English Plus.
 <!-- more -->
-

--- a/_posts/2017-04-21-hull.md
+++ b/_posts/2017-04-21-hull.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Hull, William D., 1918-1984. Papers, 1906-1984. Collection, (bulk dates 1935-1979). 12.5 cubic ft.
+title: Hull, William D. (1918-1984) Papers, 1906-1984
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ The William D. Hull collection at Hofstra University consists of the personal an
 
 The collection includes personal and family correspondence, correspondence relating to his career as a professor at Hofstra and other institutions, and as a Fulbright scholar lecturing at universities in Sri Lanka and India; manuscripts of essays and lectures, poems, verse dramas, and his ten-volume poetic work Visions of Handy Hopper; magazines and books containing poems and articles by Hull; audiotapes of Hull reading his works, photographs, music manuscripts, drawings and sketches; personal items and artifacts.
 <!-- more -->
-

--- a/_posts/2017-04-21-lent.md
+++ b/_posts/2017-04-21-lent.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Lent, Norman F. (March 23, 1931 - .), Collection, 1971-1992. 123 scrapbooks, 3 boxes of photographs 72.0 cubic ft.
+title: Lent, Norman F. (March 23, 1931 - ). Collection, 1971-1992
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The Congressman Norman F. Lent Collection is comprised of documents from Lent’s public service in the New York State Senate, and the United Stated Congress as a representative for New York State’s Fourth and Fifth Congressional Districts. The collection was donated by Congressman Lent and consists of scrapbooks constructed by Mr. Lent during his tenure as congressman, from September 1962 to June 1992. It focuses on local, state, and federal policy and the effects of legislation on Long Island. The scrapbooks contain election materials, congressional records, newspaper and magazine articles, official government letters, photographs, White House event invitations, keepsake items and photographs. This collection is organized chronologically in the form of scrap books. Noteworthy items include White House event invitations, Presidential inauguration event materials, photographs, congressional polling material, election materials, and congressional district surveys.
 <!-- more -->
-

--- a/_posts/2017-04-21-mitchell.md
+++ b/_posts/2017-04-21-mitchell.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Mitchell, Broadus, 1892-1988. Collection, 1926-1975 (bulk dates 1926-1941, 1957-1958). 6.0 cubic ft.
+title: Mitchell, Broadus (1892-1988). Collection, 1926-1975
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The Broadus Mitchell Collection at Hofstra University contains family correspondence, professional correspondence and organizational correspondence which detail the events in Mitchell’s life. Also included are print materials, manuscript materials, a small amount of financial documents and personal items. Mitchell taught economics at Johns Hopkins from 1919 to 1939. He ran for Governor of Maryland in 1934 on the Socialist Party ticket. He spent successive years at Occidental College in California from 1939 to 1941 and at New York University from 1942 to 1944. He also taught at Rutgers from 1949 to 1958. Mitchell came to Hofstra’s New College in 1958 and retired in 1967 at 75; he received an Honorary Degree from Hofstra in 1967. In Tarrytown, New York he died at the age of 95.
 <!-- more -->
-

--- a/_posts/2017-04-21-physicians-for-social-responsibility-(nassau-county-chapter)-(1982-1997)--collection.md
+++ b/_posts/2017-04-21-physicians-for-social-responsibility-(nassau-county-chapter)-(1982-1997)--collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Physicians for Social Responsibility (Nassau County Chapter) (1982-1997). Collection, 1948-2000. 8.5 cubic ft.
+title: Physicians for Social Responsibility (Nassau County Chapter) (1982-1997). Collection, 1948-2000
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The Nassau County Chapter of Physicians for Social Responsibility (PSR-NC) was an organization which protested nuclear war in the '80s and '90s. The group gave lectures, held fundraisers, led protests, as well as other events, in order to educate the general population on the topic of nuclear war and to promote world peace.
 <!-- more -->
-

--- a/_posts/2017-04-21-pinter.md
+++ b/_posts/2017-04-21-pinter.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Pinter, Harold. Collection, 1960-1971. 2.0 cubic ft.
+title: Pinter, Harold. Collection, 1960-1971
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The Pinter Collection is comprised of clippings, correspondence, theatrical programs, scripts, and interviews including documents and audiovisual materials. The items in the collection relate mostly to Harold Pinter's work as a playwright and screenwriter. The bulk of the collection include scripts and programs from Pinter's plays that were performed in the 1960s and 1970s.
 <!-- more -->
-

--- a/_posts/2017-04-21-places-of-worship--collection.md
+++ b/_posts/2017-04-21-places-of-worship--collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Places of Worship. Collection, 2000-2002. 5.3 cubic ft.
+title: Places of Worship. Collection, 2000-2002
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 In the year 2000, Hofstra University alumnus Robert L. Harrison began his quest to photograph all the places of worship in Nassau County. Eighteen months and over 3000 miles later, he had completed a stunning visual record of the religious diversity in this rapidly changing area of Long Island. This collection contains all of the images captured by Harrison during his photographic odyssey.(Note: Harrison added a small number of photographs to the collection in 2002. Also, the collection does include some photographs of places of worship located in Suffolk County).
 <!-- more -->
-

--- a/_posts/2017-04-21-popular-culture-collection.md
+++ b/_posts/2017-04-21-popular-culture-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Popular Culture Collection, Comic Books and Publications, 1875-current. 25.0 cubic ft.
+title: Popular Culture Collection, Comic Books and Publications, 1875-current
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The term “popular culture” evades easy definition. For some, it is any aspect of culture that is aimed at and appreciated by a large segment of a society. Some conceive of it as inherently unsophisticated, standing in opposition to higher forms of culture. Others consider it to be necessarily commercialized, and primarily existent to make money. This collection includes comic books, graphic novels, newspapers, magazines, realia and books.
 <!-- more -->
-

--- a/_posts/2017-04-21-post-family-collection.md
+++ b/_posts/2017-04-21-post-family-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Post Family Collection, 1796-1935. 3.6 cubic ft.
+title: Post Family Collection, 1796-1935
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ The bulk of this collection is comprised of letters written to Long Island Quake
 
 Particularly noteworthy items include the following: a photographic print of abolitionist Mary H. (Post) Hallowell (daughter of Isaac Post), whose home in Rochester, NY, was a stop on the Underground Railroad; a framed silhouette print of the famous Quaker preacher, Elias Hicks; a framed engraving of Lucretia Mott; and indentures related to the sale of land in Merrick as well as other locations. Also notable are photographic prints of Joseph Post, Mary Post, Esther Robbins, Willet S. Robbins, Mary Willis, Henry Willis, and Isaac Post.
 <!-- more -->
-

--- a/_posts/2017-04-21-rushmore-family-collection.md
+++ b/_posts/2017-04-21-rushmore-family-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Rushmore Family Collection, 1811-1997. 10.0 cubic ft.
+title: Rushmore Family Collection, 1811-1997
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ The Rushmores were a prominent Quaker farm family in Nassau County for over 250 
 
 Collection spans the years 1811-1997, and includes account books, autograph books, genealogies, guest books, letters, manuscripts, maps, news clippings, notebooks, notes, photo albums (including cartes de visite albums), photographs, postcards, printed materials, publications, school papers, scrapbooks, typescripts, and videotapes.
 <!-- more -->
-

--- a/_posts/2017-04-21-september-11-project-collection.md
+++ b/_posts/2017-04-21-september-11-project-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: September 11 Project Collection, 2001- . 25.5 cubic ft.
+title: September 11 Project Collection, 2001-current
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The September 11 Project Collection, which is composed of material created by Long Island residents and businesses, consists mainly of records of September 2001 and the following months. Strong areas of the collection include e-mail documents, photographs and artifacts produced by or related to the events of September 11 and the recovery effort.
 <!-- more -->
-

--- a/_posts/2017-04-21-smith-wallace-family-collection.md
+++ b/_posts/2017-04-21-smith-wallace-family-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: 'Smith/Wallace Family Collection, 1767-1996. (Bulk Dates: 1880-1940). 20.7 cubic ft.'
+title: 'Smith/Wallace Family Collection, 1767-1996'
 categories: special-collections
 published: true
 feature: false

--- a/_posts/2017-04-21-speno.md
+++ b/_posts/2017-04-21-speno.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Speno, Senator Edward J., 1920-1971. Papers, 1935-1973 (bulk dates 1954-1973).  33.3 cubic ft.
+title: Speno, Senator Edward J., 1920-1971. Papers, 1935-1973
 categories: special-collections
 published: true
 feature: false
@@ -15,4 +15,3 @@ Speno was a New York State Senator from 1954-1971. As Senator and as Chairman of
 
 The collection is comprised of biographical information about Senator Speno; correspondence; constituent requests; subject files on transportation, public health and educational funding; correspondence, administrative papers, and records of public hearings and meetings of the Joint Legislative Committee on Transportation; public statements and press releases; legislation, and twenty five scrapbooks.
 <!-- more -->
-

--- a/_posts/2017-04-21-wachtel.md
+++ b/_posts/2017-04-21-wachtel.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Wachtel, Harry H., 1917-1997. Papers, 1950-1990 (bulk dates 1960-1980). 27.0 cubic ft.
+title: Wachtel, Harry H., 1917-1997. Papers, 1950-1990
 categories: special-collections
 published: true
 feature: false
@@ -9,4 +9,3 @@ excerpt_separator: <!-- more -->
 ---
 The Hofstra University Archives, through Trustee Emeritus Bernard Fixler and Mrs. Lucy Wachtel, were given Harry Wachtel’s Papers, The collection, encompassing approximately 15.0 cubic feet of paper documentation, with an additional 12.0 cf. of print materials, is arranged in seventeen series. The materials include information about a variety of Supreme Court cases, organizations such as the Southern Christian Leadership Conference, many aspects of civil rights, and Wachtel’s trip with King and his supporters to Norway to receive the Nobel Peace Prize in 1964.
 <!-- more -->
-

--- a/_posts/2017-04-21-woman's-forum-of-nassau-county-scrapbook-collection.md
+++ b/_posts/2017-04-21-woman's-forum-of-nassau-county-scrapbook-collection.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Woman's Forum of Nassau County Scrapbook Collection, 1957-1995. 3.0 cubic ft.
+title: Woman's Forum of Nassau County Scrapbook Collection, 1957-1995
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ The Woman’s Forum of Nassau County was founded in 1944 by Elizabeth Bass Goldi
 
 The thirteen scrapbooks that make up this collection document the activities of the organization from 1957-1995. They were compiled by Bernice F. Weshler, who was the publicity director and a past president of the Woman’s Forum.
 <!-- more -->
-

--- a/_posts/2017-04-21-zarb.md
+++ b/_posts/2017-04-21-zarb.md
@@ -1,6 +1,6 @@
 ---
 layout: special-collection
-title: Zarb, Frank G., 1935- . Collection, 1948-2014. 25.0 cubic ft.
+title: Zarb, Frank G., 1935- . Collection, 1948-2014
 categories: special-collections
 published: true
 feature: false
@@ -12,4 +12,3 @@ Frank Zarb has been a cabinet member or an advisor to five United States Preside
 
 The collection webpage includes biographical information about Frank G. Zarb, the finding aid to his collected materials in the Special Collections Department of Hofstra University’s Library, a digital scrapbook of photographs and captions created from materials in the archival collection, a link to Mr. Zarb’s papers in the Gerald Ford Presidential Library and a series of excerpts from Oral Histories taken over the course of a year which examine Mr. Zarb’s many contributions to both US and New York State history. The full oral history interviews are also available in the Special Collections Department.
 <!-- more -->
-


### PR DESCRIPTION
From John:
"From our Top Right Motto on all pages, DELETE Finding  [It should read "Digital Solutions to Problems in Scholarship and Learning"]
From the Special Collections titles, REMOVE the cubic feet dimensions"